### PR TITLE
fix: prevent memory leak in EnvironmentResolver for long-running workers

### DIFF
--- a/src/EnvironmentResolver.php
+++ b/src/EnvironmentResolver.php
@@ -9,23 +9,21 @@ use Dotenv\Dotenv;
 final class EnvironmentResolver
 {
     /** @var array<string, mixed> */
-    private array $env;
+    private array $dotenvVars;
 
     public function __construct(string $projectRootDir)
     {
         $dotenv = Dotenv::createImmutable($projectRootDir);
-        $this->env = $dotenv->safeLoad();
+        $this->dotenvVars = $dotenv->safeLoad();
     }
 
     public function get(string $key, mixed $default = null, bool $raw = false): mixed
     {
-        $this->env = $this->env + $_ENV;
+        $value = $_ENV[$key] ?? $this->dotenvVars[$key] ?? null;
 
-        if (!array_key_exists($key, $this->env) || $this->env[$key] === null || $this->env[$key] === '') {
+        if ($value === null || $value === '') {
             return $default;
         }
-
-        $value = $this->env[$key];
 
         if ($raw || !is_string($value)) {
             return $value;

--- a/tests/Unit/EnvironmentResolverTest.php
+++ b/tests/Unit/EnvironmentResolverTest.php
@@ -109,4 +109,21 @@ class EnvironmentResolverTest extends TestCase
 
         $this->assertEquals('default', $value);
     }
+
+    #[Test]
+    public function it_should_not_leak_memory_on_multiple_calls(): void
+    {
+        $_ENV['TEST_MEMORY'] = 'test_value';
+
+        $memoryBefore = memory_get_usage();
+
+        for ($i = 0; $i < 10000; $i++) {
+            $this->resolver->get('TEST_MEMORY');
+        }
+
+        $memoryAfter = memory_get_usage();
+        $memoryDiff = $memoryAfter - $memoryBefore;
+
+        $this->assertLessThan(100000, $memoryDiff, 'Memory leak detected: ' . $memoryDiff . ' bytes');
+    }
 }


### PR DESCRIPTION
BREAKING: Removed array merge on every get() call that could accumulate memory. Now directly reads from $_ENV with fallback to dotenv vars without mutation.

Added stress test to verify no memory leak on 10k+ calls.